### PR TITLE
Fix the double dataset issue by only selecting the inner most audio.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ __pycache__/
 .DS_Store
 .conda
 # name of folder for data in project_name/data
-uwrfkaggler/
+ravdess-audio/
+
 # Don't sync the trained models to gihub
 saved_models/
 # Don't sync the uploaded files to github

--- a/download_dataset.py
+++ b/download_dataset.py
@@ -7,21 +7,23 @@ destination_dir = os.path.join(
     os.getcwd(),
     "project_name",
     "data",
-    "uwrfkaggler",
-    "ravdess-emotional-speech-audio",
-    "versions"
+    "ravdess-audio",
 )
-DATASET_DIR = os.path.join(destination_dir, "1")
+DATASET_DIR = os.path.join(destination_dir, '1', 'audio_speech_actors_01-24')
 
 if __name__ == "__main__":
-    path = kagglehub.dataset_download(
-        "uwrfkaggler/ravdess-emotional-speech-audio"
-    )
+    if not os.path.exists(DATASET_DIR):
+        # If the dataset has not been downloaded.
+        path = kagglehub.dataset_download(
+            "uwrfkaggler/ravdess-emotional-speech-audio"
+        )
 
-    # Move the dataset to a specific directory
-    if not os.path.exists(destination_dir):
-        os.makedirs(destination_dir)
-    source_dir = path
+        # Move the dataset to a specific directory
+        if not os.path.exists(destination_dir):
+            os.makedirs(destination_dir)
+        source_dir = path
 
-    shutil.move(source_dir, destination_dir)
+        shutil.move(source_dir, destination_dir)
+    else:
+        print("Dataset has already been downloaded.")
     print("Path to dataset files:", DATASET_DIR)

--- a/project_name/data/data_file_splitting.py
+++ b/project_name/data/data_file_splitting.py
@@ -85,6 +85,14 @@ class DataFileSplitter:
         if self._audio_paths:  # Already collected
             return
 
+        # The dataset should exist, otherwise no filepaths will be collected
+        if not os.path.isdir(self._dataset_path):
+            raise FileNotFoundError(
+                f"Dataset path '{self._dataset_path}' does not exist or is"
+                " not a directory.\nPlease make sure the dataset is downloaded"
+                " and placed at this location."
+            )
+
         for root, _, files in os.walk(self._dataset_path):
             for file in files:
                 if file.endswith(".wav"):


### PR DESCRIPTION
Fix the double dataset issue by only selecting the inner most audio. In folder 1, there were actor1-24 but there was also another folder with actor 1-24. So I made the new directory the inner folder with actor 1-24. I also added a check when finding datapaths whether the dataset has been downloaded or not. Otherwise it would try to traverse a non existent folder and return nothing. It would raise wierd errors as other functions would stop working without clear indication why.