### PR TITLE
Removed the val portion of the split dataset produ

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,8 +26,8 @@ if __name__ == "__main__":
     #                 Data Loading (MFCC)
     # ____________________________________________
     # Initialize the data file splitter
-    splitter = DataFileSplitter(dataset_path=DATASET_DIR, test_size=0.1, eval_size=0.1, seed=seed)
-    train_data, val_data, test_data = splitter.get_data_splits_copy()
+    splitter = DataFileSplitter(dataset_path=DATASET_DIR, test_size=0.1, seed=seed)
+    train_data, test_data = splitter.get_data_splits_copy()
 
     # ____________________________________________
     #         Spectrogram Preprocessing

--- a/project_name/data/data_file_splitting.py
+++ b/project_name/data/data_file_splitting.py
@@ -6,13 +6,12 @@ from copy import deepcopy
 class DataFileSplitter:
     """
     Extract .wav files from dataset_path together with their label and split
-    them into train/validation/test groups.
+    them into train and test groups.
     """
     def __init__(
             self,
             dataset_path: str,
             test_size: float = 0.10,
-            eval_size: float = 0.10,
             seed: int | None = None
     ) -> None:
         """
@@ -22,21 +21,17 @@ class DataFileSplitter:
             dataset_path (str): Root path to dataset with .wav files.
             test_size (float, optional): Proportion of data to reserve for
                 test set. Defaults to 0.10.
-            eval_size (float, optional): Proportion of data to reserve for
-                validation set. Defaults to 0.10.
             seed (int | None, optional): Random seed for reproducibility.
                 Defaults to None.
         """
         self._dataset_path = dataset_path
         self.test_size = test_size
-        self.eval_size = eval_size
         self.seed = seed
 
         self._audio_paths = []  # list[str]
         self._labels = []  # list[tuple[int, int]]
 
         self._train_set = None  # list[tuple[str, tuple[int, int]]] | None
-        self._val_set = None  # list[tuple[str, tuple[int, int]]] | None
         self._test_set = None  # list[tuple[str, tuple[int, int]]] | None
 
         self._collect_files_labels()  # Collect files and labels at the start
@@ -54,16 +49,14 @@ class DataFileSplitter:
     def get_data_splits_copy(self) -> tuple[
         list[tuple[str, tuple[int, int]]],
         list[tuple[str, tuple[int, int]]],
-        list[tuple[str, tuple[int, int]]]
     ]:
         """
-        Return a deepcopy of the data in training/validation/testing sets.
+        Return a deepcopy of the data in training and testing sets.
 
         Returns:
             tuple[ list[tuple[str, tuple[int, int]]],
-                  list[tuple[str, tuple[int, int]]],
                   list[tuple[str, tuple[int, int]]] ]:
-                A tuple containing the training, validation, and test sets.
+                A tuple containing the training and test sets.
 
                 Each set is a list of samples, where each sample is a tuple:
                 (filepath, (emotion_label, intensity_label)).
@@ -76,7 +69,6 @@ class DataFileSplitter:
             self._split()
         return (
             deepcopy(self._train_set),
-            deepcopy(self._val_set),
             deepcopy(self._test_set)
         )
 
@@ -130,24 +122,14 @@ class DataFileSplitter:
         self._labels.append((int(parts[2]), int(parts[3])))
 
     def _split(self) -> None:
-        """Split the data into training/validation/testing sets."""
-        # First split into train and temp (val + test)
-        train_paths, temp_paths, train_labels, temp_labels = train_test_split(
+        """Split the data into training and testing sets."""
+        # Split into train and test
+        train_paths, test_paths, train_labels, test_labels = train_test_split(
             self._audio_paths, self._labels,
-            test_size=self.test_size + self.eval_size,
+            test_size=self.test_size,
             stratify=self._labels,
             random_state=self.seed
         )
 
-        # Now split temp into val and test
-        val_ratio = self.eval_size / (self.test_size + self.eval_size)
-        val_paths, test_paths, val_labels, test_labels = train_test_split(
-            temp_paths, temp_labels,
-            test_size=1 - val_ratio,
-            stratify=temp_labels,
-            random_state=self.seed
-        )
-
         self._train_set = list(zip(train_paths, train_labels))
-        self._val_set = list(zip(val_paths, val_labels))
         self._test_set = list(zip(test_paths, test_labels))


### PR DESCRIPTION
Removed the validation set functionality from the data splitter, seeing as it is not used anymore because 
the training procedure now splits the training set into training and eval depending on 
pipeline requirements. The val set was removing 10% of our dataset unnecessarily 